### PR TITLE
Fix race on focus serial by using atomic counter

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -817,15 +817,15 @@ Window x11_win(steamcompmgr_win_t *w) {
 	return w->xwayland().id;
 }
 
-static uint64_t s_ulFocusSerial = 0ul;
+static std::atomic<uint64_t> s_ulFocusSerial{ 0ul };
 void MakeFocusDirty()
 {
-	s_ulFocusSerial++;
+       s_ulFocusSerial.fetch_add( 1, std::memory_order_relaxed );
 }
 
 static inline uint64_t GetFocusSerial()
 {
-	return s_ulFocusSerial;
+       return s_ulFocusSerial.load( std::memory_order_relaxed );
 }
 
 bool focus_t::IsDirty()


### PR DESCRIPTION
## Summary
- make the focus serial counter an atomic
- use atomic fetch/add and load in MakeFocusDirty() and GetFocusSerial()

## Testing
- `meson setup build` *(fails: `meson: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6855c4a6bdcc832f940f21a8db5e3bba